### PR TITLE
Update XApp Model Window

### DIFF
--- a/src/screens/Modal/XAppBrowser/styles.tsx
+++ b/src/screens/Modal/XAppBrowser/styles.tsx
@@ -5,7 +5,10 @@ import StyleService from '@services/StyleService';
 
 /* Styles ==================================================================== */
 const styles = StyleService.create({
-    container: { flex: 1 },
+    container: { 
+        position:'fixed',
+        flex: 1 
+    },
     webViewContainer: {
         flex: 1,
         backgroundColor: '$background',

--- a/src/screens/Modal/XAppBrowser/styles.tsx
+++ b/src/screens/Modal/XAppBrowser/styles.tsx
@@ -6,10 +6,10 @@ import StyleService from '@services/StyleService';
 /* Styles ==================================================================== */
 const styles = StyleService.create({
     container: { 
-        position:'fixed',
         flex: 1 
     },
     webViewContainer: {
+        position:'fixed',
         flex: 1,
         backgroundColor: '$background',
     },


### PR DESCRIPTION
- Update to prevent overflow scrolling of xApp model window

Overflow scrolling should be disabled for xApp modal windows. This would give developers the ability to define LOCAL overscroll functionality within their apps (ie. refresh page)